### PR TITLE
Load user flags

### DIFF
--- a/ungoogled-chromium.sh
+++ b/ungoogled-chromium.sh
@@ -60,6 +60,8 @@ if [ -n "$XDG_CONFIG_HOME" ]; then
 elif [ -n "$HOME" ]; then
     USER_FLAGS_LOCATION="$HOME/.config/chromium-flags.conf"
 fi
-CHROMIUM_DISTRO_FLAGS+=`cat $USER_FLAGS_LOCATION`
+if [ -f $USER_FLAGS_LOCATION ]; then
+    CHROMIUM_DISTRO_FLAGS+=`cat $USER_FLAGS_LOCATION`
+fi
 
 exec -a "$0" "$HERE/@@CHROMIUM_BROWSER_CHANNEL@@" $CHROMIUM_DISTRO_FLAGS "$@"

--- a/ungoogled-chromium.sh
+++ b/ungoogled-chromium.sh
@@ -55,9 +55,11 @@ CHROMIUM_DISTRO_FLAGS=" --enable-plugins \
 
 
 # Load user flags
-USER_FLAGS_LOCATION="$HOME/.config/chromium-flags.conf"
-if [ -f $USER_FLAGS_LOCATION ]; then
-    CHROMIUM_DISTRO_FLAGS+=`cat $USER_FLAGS_LOCATION`
+if [ -n "$XDG_CONFIG_HOME" ]; then
+    USER_FLAGS_LOCATION="$XDG_CONFIG_HOME/chromium-flags.conf"
+elif [ -n "$HOME" ]; then
+    USER_FLAGS_LOCATION="$HOME/.config/chromium-flags.conf"
 fi
+CHROMIUM_DISTRO_FLAGS+=`cat $USER_FLAGS_LOCATION`
 
 exec -a "$0" "$HERE/@@CHROMIUM_BROWSER_CHANNEL@@" $CHROMIUM_DISTRO_FLAGS "$@"

--- a/ungoogled-chromium.sh
+++ b/ungoogled-chromium.sh
@@ -53,4 +53,11 @@ CHROMIUM_DISTRO_FLAGS=" --enable-plugins \
                         --disallow-signin \
                         --auto-ssl-client-auth @@EXTRA_FLAGS@@"
 
+
+# Load user flags
+USER_FLAGS_LOCATION="$HOME/.config/chromium-flags.conf"
+if [ -f $USER_FLAGS_LOCATION ]; then
+    CHROMIUM_DISTRO_FLAGS+=`cat $USER_FLAGS_LOCATION`
+fi
+
 exec -a "$0" "$HERE/@@CHROMIUM_BROWSER_CHANNEL@@" $CHROMIUM_DISTRO_FLAGS "$@"


### PR DESCRIPTION
Not sure about other builds, but the Fedora one does not load user flags provided in `$HOME/.config/chromium-flags.conf`.

I tried to use `$XDG_CONFIG_HOME`, but looks like the default environment does not set it.